### PR TITLE
fixed one compiling warning and one compiling error

### DIFF
--- a/dht-bootstrap.c
+++ b/dht-bootstrap.c
@@ -114,11 +114,6 @@ static int parse_message(const unsigned char *buf, int buflen,
                          int *want_return);
 
 static const unsigned char zeroes[20] = {0};
-static const unsigned char ones[20] = {
-    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-    0xFF, 0xFF, 0xFF, 0xFF
-};
 static const unsigned char v4prefix[16] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0, 0, 0, 0
 };

--- a/dht-bootstrap.c
+++ b/dht-bootstrap.c
@@ -993,7 +993,7 @@ send_error(struct sockaddr *sa, int salen,
 #undef ADD_V
 
 #ifndef HAVE_MEMMEM
-static void *
+void *
 memmem(const void *haystack, size_t haystacklen,
        const void *needle, size_t needlelen)
 {


### PR DESCRIPTION
while compiling under openwrt with a strict warning options, there are two errors.
One warning is for unused global variable.
Another error is for memmem function declaration which is inconsistent with the standard header, and need to change from static to non-static.